### PR TITLE
Use FRHIGPUTextureReadback for Image download from GPU to CPU (Async/Non-Blocking Texture transfer)

### DIFF
--- a/Plugin/CameraCaptureToDisk/Source/CameraCaptureToDisk/Public/CameraCaptureManager.h
+++ b/Plugin/CameraCaptureToDisk/Source/CameraCaptureToDisk/Public/CameraCaptureManager.h
@@ -10,19 +10,16 @@ class UMaterial;
 #include "Containers/Queue.h"
 #include "CameraCaptureManager.generated.h"
 
-
-
-
-USTRUCT()
 struct FRenderRequestStruct{
-    GENERATED_BODY()
-
-    TArray<FColor> Image;
+    FIntPoint ImageSize;
+    FRHIGPUTextureReadback Readback;
     FRenderCommandFence RenderFence;
 
-    FRenderRequestStruct(){
-
-    }
+    FRenderRequestStruct(
+        const FIntPoint& ImageSize,
+        const FRHIGPUTextureReadback& Readback) :
+            ImageSize(ImageSize),
+            Readback(Readback) {}
 };
 
 
@@ -67,7 +64,7 @@ public:
 
 protected:
 	// RenderRequest Queue
-    TQueue<FRenderRequestStruct*> RenderRequestQueue;
+    TQueue<TSharedPtr<FRenderRequestStruct>> RenderRequestQueue;
 
     int ImgCounter = 0;
 


### PR DESCRIPTION
This PR changes the way how images get downloaded from the GPU to the CPU.

Instead of using `ReadSufaceData` it will use the `FRHIGPUTextureReadback` structure to download the image from GPU to CPU asnychronously.
This prevents the GPU from Blocking when the entire texture is transfered.
This also means it can take multiple frames till a texture finishes transfering.

After the Texture Readback is enqued, we not only check the render fence but also if the readback is ready.
Afterwards we lock the resource and get the pointer to the raw data.
Because we don't know the allocation size we have to calculate it our-self based on the additonally passed image size FIntPoint.

Additonally instead of raw pointers to the RenderRequest structures, the code now uses Reference Counted Shared Pointers.